### PR TITLE
Feature/ml api

### DIFF
--- a/src/services/user-portfolio/hooks/handleRequest.js
+++ b/src/services/user-portfolio/hooks/handleRequest.js
@@ -126,7 +126,7 @@ module.exports =
         return prepBadResponse(monitoringRecord, 'Portfolio name not specified');
 
       //sets the recommend array for the portfolio
-      setRecommend(data.portfolio)
+      setRecommend(data.portfolio);
 
       const update = {$addToSet: {'portfolios': data.portfolio}};
       const validation = await Promise.resolve(dbService.get(mongoUserID, null));
@@ -207,7 +207,7 @@ module.exports =
       const interParams = {};
       interParams.query = {'portfolios.id': data.portfolioId};
       const interUpdate = {$set: {'portfolios.$.recommend': new Array()}};
-      const resetRecommend = await Promise.resolve(dbService.patch(mongoUserID, interUpdate, interParams))
+      const resetRecommend = await Promise.resolve(dbService.patch(mongoUserID, interUpdate, interParams));
 
       const monitoringDesc = 'Added asset to portfolio ' + data.portfolioId + ' of user ' + userID + ' with instrumentId: ' + data.asset.instrumentId;
       saveMonitoringRecord.saveRecord(monitoringRecord, true, monitoringDesc);
@@ -224,7 +224,7 @@ module.exports =
         return prepBadResponse(monitoringRecord, 'Asset id not specified');
       if (isNaN(data.assetId))
         return prepBadResponse(monitoringRecord, 'Asset id is not a number');
-      data.assetId = String(data.assetId)
+      data.assetId = String(data.assetId);
 
       const params = {};
       params.query = {'portfolios.id': data.portfolioId};
@@ -255,7 +255,7 @@ module.exports =
         const interParams = {};
         interParams.query = {'portfolios.id': data.portfolioId};
         const interUpdate = {$set: {'portfolios.$.recommend': new Array()}};
-        const resetRecommend = await Promise.resolve(dbService.patch(mongoUserID, interUpdate, interParams))
+        const resetRecommend = await Promise.resolve(dbService.patch(mongoUserID, interUpdate, interParams));
 
         const monitoringDesc = 'Removed asset from portfolio ' + data.portfolioId + ' of user ' + userID + ' with instrumentId: ' + data.assetId;
         saveMonitoringRecord.saveRecord(monitoringRecord, true, monitoringDesc);
@@ -300,12 +300,12 @@ module.exports =
 
       const params = {};
       params.query = {'portfolios.id': data.portfolioId};
-      const update = {$push: {'portfolios.$.recommend': data.value}}
+      const update = {$push: {'portfolios.$.recommend': data.value}};
 
       
 
       //missing validations?
-      const result = await Promise.resolve(dbService.patch(mongoUserID, update, params))
+      const result = await Promise.resolve(dbService.patch(mongoUserID, update, params));
 
 
 
@@ -330,7 +330,7 @@ module.exports =
         if(isNaN(data.values[i]))
           return prepBadResponse(monitoringRecord, 'An element of values is not a number');
         else
-          data.values[i] = Number(data.values[i])
+          data.values[i] = Number(data.values[i]);
       }
 
 
@@ -339,7 +339,7 @@ module.exports =
       const update = {$set: {'portfolios.$.recommend': data.values}};
 
       //missing validations?
-      const result = await Promise.resolve(dbService.patch(mongoUserID, update, params))
+      const result = await Promise.resolve(dbService.patch(mongoUserID, update, params));
 
       const monitoringDesc = 'Set recommend of Portfolio ' + data.portfolioId + ' to ' + data.values + ' of user ' + userID;
       saveMonitoringRecord.saveRecord(monitoringRecord, true, monitoringDesc);
@@ -349,7 +349,7 @@ module.exports =
 
     //returns user
     case 'getUser':{
-      return await Promise.resolve(dbService.get(mongoUserID,null))
+      return await Promise.resolve(dbService.get(mongoUserID,null));
     }
 
     default:

--- a/src/services/user-portfolio/hooks/handleRequest.js
+++ b/src/services/user-portfolio/hooks/handleRequest.js
@@ -4,78 +4,14 @@ const {NotFound, GeneralError, BadRequest} = require('@feathersjs/errors');
 const createMongoID = require('../../../helper/createMongoID');
 const saveMonitoringRecord = require('../../../helper/saveMonitoringRecord');
 
-//Helper Methods
-function noUser(record) {
-  const badRequest = new BadRequest('No user specified');
-  saveMonitoringRecord.saveRecord(record, false, 'No user specified');
+//Helper Method
+function prepBadResponse(record, msg){
+  const badRequest = new BadRequest(msg);
+  saveMonitoringRecord.saveRecord(record, false, msg);
   return Promise.reject(badRequest);
 }
 
-function noId(record) {
-  const badRequest = new BadRequest('No user id specified');
-  saveMonitoringRecord.saveRecord(record, false, 'No user id specified');
-  return Promise.reject(badRequest);
-}
 
-function noUpdates(record) {
-  const badRequest = new BadRequest('No user updates in data found');
-  saveMonitoringRecord.saveRecord(record, false, 'No user updates in data found');
-  return Promise.reject(badRequest);
-}
-
-function idIsNan(record) {
-  const badRequest = new BadRequest('User id is not a number');
-  saveMonitoringRecord.saveRecord(record, false, 'User id is not a number');
-  return Promise.reject(badRequest);
-}
-
-function noPortfolio(record) {
-  const badRequest = new BadRequest('No portfolio specified');
-  saveMonitoringRecord.saveRecord(record, false, 'No portfolio specified');
-  return Promise.reject(badRequest);
-}
-
-function noPortfolioId(record) {
-  const badRequest = new BadRequest('No portfolio id specified');
-  saveMonitoringRecord.saveRecord(record, false, 'No portfolio id specified');
-  return Promise.reject(badRequest);
-}
-
-function portfIdIsNan(record) {
-  const badRequest = new BadRequest('Portfolio id is not a number');
-  saveMonitoringRecord.saveRecord(record, false, 'Portfolio id is not a number');
-  return Promise.reject(badRequest);
-}
-
-function noPortfName(record) {
-  const badRequest = new BadRequest('Portfolio name not specified');
-  saveMonitoringRecord.saveRecord(record, false, 'Portfolio name not specified');
-  return Promise.reject(badRequest);
-}
-
-function noAsset(record) {
-  const badRequest = new BadRequest('Asset not specified');
-  saveMonitoringRecord.saveRecord(record, false, 'Asset not specified');
-  return Promise.reject(badRequest);
-}
-
-function assetFormat(record) {
-  const badRequest = new BadRequest('Asset not formatted correctly');
-  saveMonitoringRecord.saveRecord(record, false, 'Asset not formatted correctly');
-  return Promise.reject(badRequest);
-}
-
-function noAssetId(record) {
-  const badRequest = new BadRequest('Asset id not specified');
-  saveMonitoringRecord.saveRecord(record, false, 'Asset id not specified');
-  return Promise.reject(badRequest);
-}
-
-function assetIdIsNan(record) {
-  const badRequest = new BadRequest('Asset id is not a number');
-  saveMonitoringRecord.saveRecord(record, false, 'Asset id is not a number');
-  return Promise.reject(badRequest);
-}
 
 function checkAsset(asset) {
   if (!asset.instrumentId || !asset.isin || !asset.name ||
@@ -88,25 +24,6 @@ function checkAsset(asset) {
 
   return true;
 
-}
-
-//new check methods for the value to be pushed to a portfolio's recommend array
-function noValue(record) {
-  const badRequest = new BadRequest('No value specified');
-  saveMonitoringRecord.saveRecord(record, false, 'No value specified');
-  return Promise.reject(badRequest);
-}
-
-function valueIsNan(record) {
-  const badRequest = new BadRequest('Value is not a number');
-  saveMonitoringRecord.saveRecord(record, false, 'Value is not a number');
-  return Promise.reject(badRequest); 
-}
-
-function noValues(record) {
-  const badRequest = new BadRequest('No array of values specified');
-  saveMonitoringRecord.saveRecord(record, false, 'No array of values specified');
-  return Promise.reject(badRequest);
 }
 
 //Helper: adds recommend (int[]) / resets it to a portfolio
@@ -145,16 +62,16 @@ module.exports =
     let userID = '';
     if (data.user) {
       if (!data.user.id)
-        return noId(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No user ID specified');
       if (isNaN(data.user.id))//case ignores submissions like 1e10000
-        return idIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'User id is not a number');
       userID = data.user.id = data.user.id.toString();
       mongoUserID = createMongoID.createUserID(data.user.id); //mongoDB id used to identify user
     } else {
       if (!data.userId)
-        return noId(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No user ID specified');
       if (isNaN(data.userId))//case ignores submissions like 1e10000
-        return idIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'User id is not a number');
       userID = data.userId = data.userId.toString();
       mongoUserID = createMongoID.createUserID(data.userId); //mongoDB id used to identify user
     }
@@ -189,7 +106,7 @@ module.exports =
         saveMonitoringRecord.saveRecord(monitoringRecord, true, 'Updated ' + key + ' field of user ' + userID + ' to: ' + value);
       }
       if (result == null) {
-        result = noUpdates(monitoringRecord);
+        result = prepBadResponse(monitoringRecord, 'No user updates in data found');
       }
 
       return result;
@@ -197,13 +114,13 @@ module.exports =
     case 'addPortfolio': {
 
       if (!data.portfolio)
-        return noPortfolio(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No portfolio specified');
       if (!data.portfolio.id)
-        return noPortfolioId(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolio.id))
-        return portfIdIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
       if (!data.portfolio.name)
-        return noPortfName(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Portfolio name not specified');
 
       //sets the recommend array for the portfolio
       setRecommend(data.portfolio)
@@ -228,9 +145,9 @@ module.exports =
     }
     case 'removePortfolio': {
       if (!data.portfolioId)
-        return noPortfolioId(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
-        return portfIdIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
 
       const update = {$pull: {'portfolios': {'id': data.portfolioId}}};
       const validation = await Promise.resolve(dbService.get(mongoUserID, null));
@@ -250,13 +167,13 @@ module.exports =
 
     case 'addPortfolioAsset': {
       if (!data.portfolioId)
-        return noPortfolioId(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
-        return portfIdIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
       if (!data.asset)
-        return noAsset(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Asset not specified');
       if (!checkAsset(data.asset))
-        return assetFormat(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Asset not formatted correctly');
 
       const params = {};
       params.query = {'portfolios.id': data.portfolioId};
@@ -294,13 +211,13 @@ module.exports =
 
     case 'removePortfolioAsset': {
       if (!data.portfolioId)
-        return noPortfolioId(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
-        return portfIdIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
       if (!data.assetId)
-        return noAssetId(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Asset id not specified');
       if (isNaN(data.assetId))
-        return assetIdIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Asset id is not a number');
 
       const params = {};
       params.query = {'portfolios.id': data.portfolioId};
@@ -342,9 +259,9 @@ module.exports =
     case'resetPortfolioRecommend': {
       
       if (!data.portfolioId)
-        return noPortfolioId(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
-        return portfIdIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
 
       
       const params = {};
@@ -363,21 +280,25 @@ module.exports =
     case'pushPortfolioRecommend':{
 
       if (!data.portfolioId)
-        return noPortfolioId(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
-        return portfIdIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
       if(!data.value)
-        return noValue(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No value specified');
       if(isNaN(data.value))
-        return valueIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Value is not a number');
 
 
       const params = {};
       params.query = {'portfolios.id': data.portfolioId};
       const update = {$push: {'portfolios.$.recommend': data.value}}
 
+      
+
       //missing validations?
       const result = await Promise.resolve(dbService.patch(mongoUserID, update, params))
+
+
 
       const monitoringDesc = 'Pushed ' + data.value + ' to recommend of Portfolio ' + data.portfolioId + ' of user ' + userID;
       saveMonitoringRecord.saveRecord(monitoringRecord, true, monitoringDesc);
@@ -388,12 +309,19 @@ module.exports =
     case'setPortfolioRecommend':{
 
       if (!data.portfolioId)
-        return noPortfolioId(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
-        return portfIdIsNan(monitoringRecord);
+        return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
       if(!data.values)
-        return noValues(monitoringRecord);
-      //check if all values of the array are int?
+        return prepBadResponse(monitoringRecord, 'No array of values specified');
+      if(!Array.isArray(data.values))
+        return prepBadResponse(monitoringRecord, 'Values is not an Array');
+      for(var i = 0; i < data.values.length; i++){
+        if(isNaN(data.values[i]))
+          return prepBadResponse(monitoringRecord, 'An element of values is not a number');
+        else
+          data.values[i] = Number(data.values[i])
+      }
 
 
       const params = {};

--- a/src/services/user-portfolio/hooks/handleRequest.js
+++ b/src/services/user-portfolio/hooks/handleRequest.js
@@ -284,7 +284,7 @@ module.exports =
       //reset recommend of that portfolio
       const interParams = {};
       interParams.query = {'portfolios.id': data.portfolioId};
-      const interUpdate = {$set: {'recommend': new Array()}};
+      const interUpdate = {$set: {'portfolios.$.recommend': new Array()}};
       const resetRecommend = await Promise.resolve(dbService.patch(mongoUserID, interUpdate, interParams))
 
       const monitoringDesc = 'Added asset to portfolio ' + data.portfolioId + ' of user ' + userID + ' with instrumentId: ' + data.asset.instrumentId;
@@ -330,7 +330,7 @@ module.exports =
         //reset recommend of that portfolio
         const interParams = {};
         interParams.query = {'portfolios.id': data.portfolioId};
-        const interUpdate = {$set: {'recommend': new Array()}};
+        const interUpdate = {$set: {'portfolios.$.recommend': new Array()}};
         const resetRecommend = await Promise.resolve(dbService.patch(mongoUserID, interUpdate, interParams))
 
         const monitoringDesc = 'Removed asset from portfolio ' + data.portfolioId + ' of user ' + userID + ' with instrumentId: ' + data.assetId;
@@ -349,7 +349,7 @@ module.exports =
       
       const params = {};
       params.query = {'portfolios.id': data.portfolioId};
-      const update = {$set: {'recommend': new Array()}};
+      const update = {$set: {'portfolios.$.recommend': new Array()}};
       
       //missing validations?
       const result = await Promise.resolve(dbService.patch(mongoUserID, update, params));
@@ -374,7 +374,7 @@ module.exports =
 
       const params = {};
       params.query = {'portfolios.id': data.portfolioId};
-      const update = {$push: {'recommend': data.value}}
+      const update = {$push: {'portfolios.$.recommend': data.value}}
 
       //missing validations?
       const result = await Promise.resolve(dbService.patch(mongoUserID, update, params))
@@ -392,13 +392,13 @@ module.exports =
       if (isNaN(data.portfolioId))
         return portfIdIsNan(monitoringRecord);
       if(!data.values)
-        return noValue(monitoringRecord);
+        return noValues(monitoringRecord);
       //check if all values of the array are int?
 
 
       const params = {};
       params.query = {'portfolios.id': data.portfolioId};
-      const update = {$set: {'recommend': data.values}};
+      const update = {$set: {'portfolios.$.recommend': data.values}};
 
       //missing validations?
       const result = await Promise.resolve(dbService.patch(mongoUserID, update, params))
@@ -407,6 +407,11 @@ module.exports =
       saveMonitoringRecord.saveRecord(monitoringRecord, true, monitoringDesc);
       return result;
 
+    }
+
+    //returns user
+    case 'getUser':{
+      return await Promise.resolve(dbService.get(mongoUserID,null))
     }
 
     default:

--- a/src/services/user-portfolio/hooks/handleRequest.js
+++ b/src/services/user-portfolio/hooks/handleRequest.js
@@ -22,6 +22,8 @@ function checkAsset(asset) {
     isNaN(asset.quantity))
     return false;
 
+  asset.instrumentId = String(asset.instrumentId);
+
   return true;
 
 }
@@ -119,6 +121,7 @@ module.exports =
         return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolio.id))
         return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
+      data.portfolio.id = String(data.portfolio.id);
       if (!data.portfolio.name)
         return prepBadResponse(monitoringRecord, 'Portfolio name not specified');
 
@@ -148,6 +151,7 @@ module.exports =
         return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
         return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
+      data.portfolioId = String(data.portfolioId);
 
       const update = {$pull: {'portfolios': {'id': data.portfolioId}}};
       const validation = await Promise.resolve(dbService.get(mongoUserID, null));
@@ -170,6 +174,7 @@ module.exports =
         return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
         return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
+      data.portfolioId = String(data.portfolioId);
       if (!data.asset)
         return prepBadResponse(monitoringRecord, 'Asset not specified');
       if (!checkAsset(data.asset))
@@ -214,10 +219,12 @@ module.exports =
         return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
         return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
+      data.portfolioId = String(data.portfolioId);
       if (!data.assetId)
         return prepBadResponse(monitoringRecord, 'Asset id not specified');
       if (isNaN(data.assetId))
         return prepBadResponse(monitoringRecord, 'Asset id is not a number');
+      data.assetId = String(data.assetId)
 
       const params = {};
       params.query = {'portfolios.id': data.portfolioId};
@@ -262,6 +269,7 @@ module.exports =
         return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
         return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
+      data.portfolioId = String(data.portfolioId);
 
       
       const params = {};
@@ -283,6 +291,7 @@ module.exports =
         return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
         return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
+      data.portfolioId = String(data.portfolioId);
       if(!data.value)
         return prepBadResponse(monitoringRecord, 'No value specified');
       if(isNaN(data.value))
@@ -312,6 +321,7 @@ module.exports =
         return prepBadResponse(monitoringRecord, 'No portfolio id specified');
       if (isNaN(data.portfolioId))
         return prepBadResponse(monitoringRecord, 'Portfolio id is not a number');
+      data.portfolioId = String(data.portfolioId);
       if(!data.values)
         return prepBadResponse(monitoringRecord, 'No array of values specified');
       if(!Array.isArray(data.values))


### PR DESCRIPTION
Feature introduces requests from the ML team.

Now, every new portfolio added automatically has a field of int array called "recommend". It's empty by default.

Adding or removing assets from the portfolio will reset the array to be empty.

In order to use the new actions, use a post request to the user-profile service (all of them require userId, portfolioId):

"action": "resetPortfolio" - resets the portfolio's recommend.
"action": "setPortfolio" - set the portfolio's recommend. requires values parameter in the body, which should be an array of int.
"action": "pushPortfolio" - add an element to the portfolio's recommend.
"action": "getUser" - will return the user object as it is stored in the user DB.